### PR TITLE
Avoid division by zero when ratingPercent is used

### DIFF
--- a/src/Rateable/Rateable.php
+++ b/src/Rateable/Rateable.php
@@ -31,7 +31,7 @@ trait Rateable
         $ratings = $this->ratings();
         $quantity = $ratings->count();
         $total = $ratings->selectRaw('SUM(rating) as total')->pluck('total');
-        return $total / (($quantity * $max) / 100);
+        return ($quantity * $max) > 0 ? $total / (($quantity * $max) / 100) : 0;
     }
 
     public function getAverageRatingAttribute()


### PR DESCRIPTION
When using ratingPercent() on an non-rated object, a zero division situation occurs. Now it will just return zero if the object wasn't rated before.