### PR TITLE
Migration

### DIFF
--- a/src/migrations/create_ratings_table.php
+++ b/src/migrations/create_ratings_table.php
@@ -15,7 +15,7 @@ class CreateRatingsTable extends Migration
             $table->timestamps();
             $table->integer('rating');
             $table->morphs('rateable');
-            $table->unsignedInteger('user_id')->index();
+            $table->bigInteger('user_id')->unsigned();
             $table->index('rateable_id');
             $table->index('rateable_type');
             $table->foreign('user_id')->references('id')->on('users');


### PR DESCRIPTION
Fixed the error

General error: 1215 Cannot add foreign key constraint (SQL: alter table `ratings` add constraint `ratings_user_id_foreign` foreign key (`user_id`) references `users` (`id`))