### PR TITLE
Fix: Allow rating user_id to be used when rating.

### DIFF
--- a/src/Rateable.php
+++ b/src/Rateable.php
@@ -56,7 +56,7 @@ trait Rateable
             $rating->comment = $comment;
             $rating->save();
         } else {
-            $this->rate($value, $comment);
+            $this->rate($value, $comment, $user_id);
         }
     }
 

--- a/src/Rateable.php
+++ b/src/Rateable.php
@@ -18,7 +18,7 @@ trait Rateable
      */
 
      private function byUser($user_id = null) {
-        if(!! $user_id) {
+        if(! $user_id) {
             return Auth::id();
         }
 


### PR DESCRIPTION
Initially, when submiting a rating, even if the `user_id` param is supplied, it is ignored and `Auth::id()` is prefered, this PR fixes that.